### PR TITLE
Change default swift bind_ports

### DIFF
--- a/elements/swift-storage/os-apply-config/etc/swift/account-server.conf
+++ b/elements/swift-storage/os-apply-config/etc/swift/account-server.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-bind_port = 6002
+bind_port = 6202
 # Once we have partitions dedicated to swift storage this should be removed
 mount_check = false
 devices = /mnt/state/srv/node

--- a/elements/swift-storage/os-apply-config/etc/swift/container-server.conf
+++ b/elements/swift-storage/os-apply-config/etc/swift/container-server.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-bind_port = 6001
+bind_port = 6201
 # Once we have partitions dedicated to swift storage this should be removed
 mount_check = false
 devices = /mnt/state/srv/node

--- a/elements/swift-storage/os-apply-config/etc/swift/object-server.conf
+++ b/elements/swift-storage/os-apply-config/etc/swift/object-server.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-bind_port = 6000
+bind_port = 6200
 # Once we have partitions dedicated to swift storage this should be removed
 mount_check = false
 devices = /mnt/state/srv/node


### PR DESCRIPTION
Change the default bind_ports to match the RDO package defaults
where object-server is on 6200, container-server is on 6201, and
account-server is on 6202.
