### PR TITLE
Allow for usage of l3_ha in neutron config instead of forcibly use l3 failover

### DIFF
--- a/elements/neutron/os-apply-config/etc/neutron/neutron.conf
+++ b/elements/neutron/os-apply-config/etc/neutron/neutron.conf
@@ -14,7 +14,11 @@ verbose={{neutron.verbose}}
 debug={{neutron.debug}}
 {{/neutron.debug}}
 
-allow_automatic_l3agent_failover = True
+{{#neutron.l3_ha}}
+l3_ha = {{neutron.l3_ha}}
+max_l3_agents_per_router = {{#neutron.max_l3_agents_per_router}}{{.}}{{/neutron.max_l3_agents_per_router}}{{^neutron.max_l3_agents_per_router}}3{{/neutron.max_l3_agents_per_router}}
+min_l3_agents_per_router = {{#neutron.min_l3_agents_per_router}}{{.}}{{/neutron.min_l3_agents_per_router}}{{^neutron.min_l3_agents_per_router}}2{{/neutron.min_l3_agents_per_router}}
+{{/neutron.l3_ha}}
 
 lock_path = /var/run/neutron/lock
 


### PR DESCRIPTION
We defaulted to failover the l3 agents but this is not very well supported and suffers
from known bugs [1], this change allows the switch to l3_ha.

It is a (crafted) cherry-pick of https://review.openstack.org/#/c/145733/
1. https://bugzilla.redhat.com/show_bug.cgi?id=1175790
