### PR TITLE
Add script to delete iptables rules

### DIFF
--- a/elements/iptables/bin/delete-rule
+++ b/elements/iptables/bin/delete-rule
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Script to delete iptables rules per element
+#
+# The only input argument is an iptables rule without the command option.
+# This case covers all of the current usage of elements that insert rules
+# in the 97-iptables files.
+# Example usage:
+# delete-rule INPUT -p tcp -m multiport --dports 3260,8776 -j ACCEPT
+# delete-rule INPUT -p tcp --dport 4730 -j ACCEPT
+# delete-rule FORWARD -d 192.0.2.0/24 -j ACCEPT
+
+set -eu
+set -o pipefail
+
+RULE="$@"
+
+DISTRO=`lsb_release -si` || true
+
+
+if [[ "RedHatEnterpriseServer RedHatEnterpriseWorkstation CentOS Fedora" =~ "$DISTRO" ]]; then
+    IPT_FILE=
+    # Check if the iptables service is active
+    if systemctl is-active iptables.service ; then
+        IPT_FILE=/etc/sysconfig/iptables
+    fi
+    if [ -f "$IPT_FILE" ]; then
+
+        iptables-restore < $IPT_FILE
+    fi
+
+    if [ -n "$IPT_FILE" ]; then
+
+        iptables -D $RULE || true
+
+        iptables-save > $IPT_FILE
+    fi
+
+elif [[ "Debian Ubuntu" =~ "$DISTRO" ]]; then
+    # NOTE(kiall): os-svc-restart etc don't support the custom 'save'
+    #              action, so we grab the name and call the service
+    #              binary "by hand" instead.
+    SERVICE_NAME=$(svc-map iptables-persistent)
+
+    service $SERVICE_NAME reload
+
+    iptables -D $RULE || true
+
+    service $SERVICE_NAME save
+
+fi


### PR DESCRIPTION
The current iptables element has a script for adding rules, but
not deleting them.  This patch adds a script that follows the
conventions of the add-rule script and provides the ability to
delete iptables rules.
